### PR TITLE
Set correct typing on deepSupplement method

### DIFF
--- a/jointjs/jointjs.d.ts
+++ b/jointjs/jointjs.d.ts
@@ -129,7 +129,7 @@ declare module joint {
         function mixin(objects:any[]):any;
         function supplement(objects:any[]):any;
         function deepMixin(objects:any[]):any;
-        function deepSupplement(objects:any[], defaultIndicator?:any):any;
+        function deepSupplement(objects:any, defaultIndicator?:any):any;
     }
 
 }


### PR DESCRIPTION
the deepSupplement method is always used as such:

joint.util.deepSupplement({

```
    type: 'basic.Path',
    size: { width: 60, height: 60 },
    attrs: {
        'path': { fill: '#FFFFFF', stroke: 'black' },
        'text': { 'font-size': 14, text: '', 'text-anchor': 'middle', 'ref-x': .5, 'ref-dy': 20, ref: 'path', 'y-alignment': 'middle', fill: 'black', 'font-family': 'Arial, helvetica, sans-serif' }
    }
}, joint.shapes.basic.Generic.prototype.defaults)
```

The first argument is therefor not an array but an object. This change reflects this.
